### PR TITLE
spec: fix golang compiler BR conditional

### DIFF
--- a/ignition.spec
+++ b/ignition.spec
@@ -14,12 +14,7 @@ Patch1: 0002-build_releases-Override-artifact-output-with-BIN_PAT.patch
 Patch2: 0001-build-Allow-VERSION-set-and-fallback-to-git.patch
 Patch3: 0002-build_releases-Allow-setting-VERSION-and-fallback-to.patch
 
-%if 0%{?fedora}
 BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang >= 1.6.2}
-%endif #fedora
-%if 0%{?centos}
-BuildRequires:  golang
-%endif #centos
 BuildRequires:  libblkid-devel
 # See https://github.com/openshift/os/issues/59
 #ExclusiveArch:  %{go_arches}


### PR DESCRIPTION
We're compiling with redhat-release-coreos in the buildroot, which
provides a `%rhel` macro, not `%centos`. Rather than adding
`|| 0%{?centos}`, let's just boil it down to an `else`.

This was causing golang to not get pulled in.